### PR TITLE
Refine BotResponse and adapter handling

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/BotResponse.java
+++ b/core/src/main/java/io/lonmstalker/core/BotResponse.java
@@ -3,9 +3,13 @@ package io.lonmstalker.core;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
 public class BotResponse {
+    private BotApiMethod<?> method;
 }

--- a/core/src/main/java/io/lonmstalker/core/bot/Bot.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/Bot.java
@@ -20,4 +20,10 @@ public interface Bot {
     boolean isStarted();
 
     void onComplete(@NonNull BotCompleteAction action);
+
+    @NonNull
+    BotConfig config();
+
+    @NonNull
+    String token();
 }

--- a/core/src/main/java/io/lonmstalker/core/bot/BotAdapterImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotAdapterImpl.java
@@ -1,15 +1,71 @@
 package io.lonmstalker.core.bot;
 
 import io.lonmstalker.core.BotAdapter;
-import org.checkerframework.checker.nullness.qual.NonNull;
+import io.lonmstalker.core.BotCommand;
+import io.lonmstalker.core.BotInfo;
+import io.lonmstalker.core.BotRequest;
+import io.lonmstalker.core.BotRequestConverter;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.interceptor.BotInterceptor;
+import io.lonmstalker.core.storage.BotRequestHolder;
+import io.lonmstalker.core.user.BotUserInfo;
+import io.lonmstalker.core.user.BotUserProvider;
+import io.lonmstalker.core.utils.UpdateUtils;
+import io.lonmstalker.core.bot.TelegramSender;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.Update;
+import java.util.List;
 
+@Slf4j
 public class BotAdapterImpl implements BotAdapter {
 
+    private final Bot bot;
+    private final BotRequestConverter<BotApiObject> converter;
+    private final BotUserProvider userProvider;
+
+    public BotAdapterImpl(@NonNull Bot bot,
+                          @NonNull BotRequestConverter<BotApiObject> converter,
+                          @NonNull BotUserProvider userProvider) {
+        this.bot = bot;
+        this.converter = converter;
+        this.userProvider = userProvider;
+    }
+
     @Override
+    @SuppressWarnings("unchecked")
     public @Nullable BotApiMethod<?> handle(@NonNull Update update) {
-        return null;
+        List<BotInterceptor> interceptors = bot.config().getGlobalInterceptors();
+        interceptors.forEach(i -> i.preHandle(update));
+        BotResponse response = null;
+        try {
+            BotRequestType type = UpdateUtils.getType(update);
+            BotApiObject data = converter.convert(update, type);
+            BotCommand<BotApiObject> command = bot.registry().find(type, data);
+            if (command == null) {
+                return null;
+            }
+            var sender = new TelegramSender(bot.config(), bot.token());
+            BotRequestHolder.setUpdate(update);
+            BotRequestHolder.setSender(sender);
+            BotUserInfo user = userProvider.resolve(update);
+            BotInfo info = new BotInfo(bot.internalId(), sender);
+            response = command.handle(new BotRequest<>(update.getUpdateId(), data, info, user));
+            interceptors.forEach(i -> i.postHandle(update));
+            return response != null ? response.getMethod() : null;
+        } finally {
+            for (BotInterceptor i : interceptors) {
+                try {
+                    i.afterCompletion(update, response);
+                } catch (Exception e) {
+                    log.error("Interceptor afterCompletion error", e);
+                }
+            }
+            BotRequestHolder.clear();
+        }
     }
 }

--- a/core/src/main/java/io/lonmstalker/core/bot/BotImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotImpl.java
@@ -82,6 +82,16 @@ public class BotImpl implements Bot {
         completeActions.add(action);
     }
 
+    @Override
+    public @NonNull BotConfig config() {
+        return this.config;
+    }
+
+    @Override
+    public @NonNull String token() {
+        return this.token;
+    }
+
     private void checkStarted() {
         if (user == null) {
             throw new BotApiException("Bot not started");

--- a/core/src/main/java/io/lonmstalker/core/interceptor/defaults/LoggingBotInterceptor.java
+++ b/core/src/main/java/io/lonmstalker/core/interceptor/defaults/LoggingBotInterceptor.java
@@ -1,0 +1,29 @@
+package io.lonmstalker.core.interceptor.defaults;
+
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.interceptor.BotInterceptor;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * Default interceptor that logs update processing steps.
+ */
+@Slf4j
+public class LoggingBotInterceptor implements BotInterceptor {
+    @Override
+    public void preHandle(@NonNull Update update) {
+        log.info("Pre handle update: {}", update);
+    }
+
+    @Override
+    public void postHandle(@NonNull Update update) {
+        log.info("Post handle update: {}", update);
+    }
+
+    @Override
+    public void afterCompletion(@NonNull Update update, @Nullable BotResponse response) {
+        log.info("After completion update: {}, response: {}", update, response);
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/user/BotUserRepository.java
+++ b/core/src/main/java/io/lonmstalker/core/user/BotUserRepository.java
@@ -1,0 +1,14 @@
+package io.lonmstalker.core.user;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+/**
+ * Interface for loading or creating user information in database.
+ */
+public interface BotUserRepository {
+    /**
+     * Returns existing user info or creates a new one based on telegram user.
+     */
+    @NonNull BotUserInfo getOrCreate(@NonNull User telegramUser);
+}

--- a/core/src/main/java/io/lonmstalker/core/user/DbBotUserProvider.java
+++ b/core/src/main/java/io/lonmstalker/core/user/DbBotUserProvider.java
@@ -1,0 +1,22 @@
+package io.lonmstalker.core.user;
+
+import io.lonmstalker.core.utils.UpdateUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+/**
+ * {@link BotUserProvider} implementation that loads user info from database.
+ */
+public class DbBotUserProvider implements BotUserProvider {
+    private final BotUserRepository repository;
+
+    public DbBotUserProvider(@NonNull BotUserRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public @NonNull BotUserInfo resolve(@NonNull Update update) {
+        var user = UpdateUtils.getUser(update);
+        return repository.getOrCreate(user);
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/utils/UpdateUtils.java
+++ b/core/src/main/java/io/lonmstalker/core/utils/UpdateUtils.java
@@ -66,4 +66,34 @@ public class UpdateUtils {
 
         throw new IllegalArgumentException("Unknown update type");
     }
+
+    /**
+     * Attempts to extract {@link org.telegram.telegrambots.meta.api.objects.User} from update.
+     *
+     * @throws IllegalArgumentException when no user information can be resolved
+     */
+    public static @NonNull org.telegram.telegrambots.meta.api.objects.User getUser(@NonNull Update update) {
+        if (update.getMessage() != null && update.getMessage().getFrom() != null) {
+            return update.getMessage().getFrom();
+        }
+        if (update.getEditedMessage() != null && update.getEditedMessage().getFrom() != null) {
+            return update.getEditedMessage().getFrom();
+        }
+        if (update.getChannelPost() != null && update.getChannelPost().getFrom() != null) {
+            return update.getChannelPost().getFrom();
+        }
+        if (update.getEditedChannelPost() != null && update.getEditedChannelPost().getFrom() != null) {
+            return update.getEditedChannelPost().getFrom();
+        }
+        if (update.getCallbackQuery() != null && update.getCallbackQuery().getFrom() != null) {
+            return update.getCallbackQuery().getFrom();
+        }
+        if (update.getInlineQuery() != null && update.getInlineQuery().getFrom() != null) {
+            return update.getInlineQuery().getFrom();
+        }
+        if (update.getChosenInlineQuery() != null && update.getChosenInlineQuery().getFrom() != null) {
+            return update.getChosenInlineQuery().getFrom();
+        }
+        throw new IllegalArgumentException("User not found in update");
+    }
 }

--- a/core/src/test/java/io/lonmstalker/core/bot/BotCommandRegistryTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotCommandRegistryTest.java
@@ -1,0 +1,38 @@
+package io.lonmstalker.core.bot;
+
+import io.lonmstalker.core.BotCommand;
+import io.lonmstalker.core.BotRequest;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.matching.AlwaysMatch;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Message;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BotCommandRegistryTest {
+    @Test
+    void addAndFindCommand() {
+        BotCommandRegistry registry = new BotCommandRegistryImpl();
+        BotCommand<Message> cmd = new BotCommand<>() {
+            @Override
+            public BotResponse handle(BotRequest<Message> request) {
+                return new BotResponse(null);
+            }
+
+            @Override
+            public BotRequestType type() {
+                return BotRequestType.MESSAGE;
+            }
+
+            @Override
+            public AlwaysMatch<Message> matcher() {
+                return new AlwaysMatch<>();
+            }
+        };
+        registry.add(cmd);
+
+        Message msg = new Message();
+        assertEquals(cmd, registry.find(BotRequestType.MESSAGE, msg));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotImplTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotImplTest.java
@@ -1,0 +1,66 @@
+package io.lonmstalker.core.bot;
+
+import io.lonmstalker.core.exception.BotApiException;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.bots.DefaultBotOptions;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.GetMe;
+import org.telegram.telegrambots.meta.api.objects.User;
+import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BotImplTest {
+
+    static class TestSender extends TelegramSender {
+        TestSender() {
+            super(new DefaultBotOptions(), "token");
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <T extends Serializable, Method extends BotApiMethod<T>> T sendApiMethod(Method method) throws TelegramApiException {
+            if (method instanceof GetMe) {
+                User user = new User();
+                user.setId(123L);
+                user.setUserName("tester");
+                return (T) user;
+            }
+            return null;
+        }
+
+        @Override
+        protected <T extends Serializable, Method extends BotApiMethod<T>> CompletableFuture<T> sendApiMethodAsync(Method method) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Test
+    void startShouldLoadUser() {
+        var bot = BotImpl.builder()
+                .id(1)
+                .token("token")
+                .config(new BotConfig())
+                .absSender(new TestSender())
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.start();
+        assertTrue(bot.isStarted());
+        assertEquals("tester", bot.username());
+    }
+
+    @Test
+    void accessWithoutStartShouldThrow() {
+        var bot = BotImpl.builder()
+                .id(1)
+                .token("token")
+                .config(new BotConfig())
+                .absSender(new TestSender())
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        assertThrows(BotApiException.class, bot::externalId);
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/TokenCipherTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/TokenCipherTest.java
@@ -1,0 +1,18 @@
+package io.lonmstalker.core.bot;
+
+import io.lonmstalker.core.utils.TokenCipher;
+import io.lonmstalker.core.utils.TokenCipherImpl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenCipherTest {
+    @Test
+    void encryptAndDecrypt() {
+        TokenCipher cipher = new TokenCipherImpl("1234567890123456");
+        String token = "secret";
+        String encrypted = cipher.encrypt(token);
+        assertNotEquals(token, encrypted);
+        assertEquals(token, cipher.decrypt(encrypted));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/UpdateUtilsTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/UpdateUtilsTest.java
@@ -1,0 +1,27 @@
+package io.lonmstalker.core.bot;
+
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.utils.UpdateUtils;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UpdateUtilsTest {
+    @Test
+    void shouldDetectMessageTypeAndExtractUser() {
+        Update update = new Update();
+        update.setUpdateId(1);
+        Message msg = new Message();
+        User user = new User();
+        user.setId(1L);
+        user.setFirstName("name");
+        msg.setFrom(user);
+        update.setMessage(msg);
+
+        assertEquals(BotRequestType.MESSAGE, UpdateUtils.getType(update));
+        assertEquals(user, UpdateUtils.getUser(update));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `method` field in `BotResponse`
- return Telegram method from adapter `handle`
- adjust registry test for new response

## Testing
- `mvn -q test` *(failed: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684d840a3dc083259b0849e1a0184e01