### PR TITLE
Add display names and positive cipher tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,5 +58,11 @@
             <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/test/java/io/lonmstalker/core/bot/BotAdapterImplTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotAdapterImplTest.java
@@ -1,0 +1,61 @@
+import io.lonmstalker.core.BotCommand;
+import io.lonmstalker.core.BotRequest;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.interceptor.BotInterceptor;
+import io.lonmstalker.core.bot.*;
+import io.lonmstalker.core.storage.BotRequestHolder;
+import io.lonmstalker.core.user.BotUserInfo;
+import io.lonmstalker.core.user.BotUserProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("BotAdapterImpl")
+class BotAdapterImplTest {
+    @Test
+    @DisplayName("handle вызывает перехватчики и очищает хранилище")
+    void handleShouldInvokeInterceptorsAndClearHolder() {
+        BotInterceptor interceptor = mock(BotInterceptor.class);
+        BotConfig config = new BotConfig();
+        config.setGlobalInterceptors(List.of(interceptor));
+
+        BotCommandRegistry registry = mock(BotCommandRegistry.class);
+        BotCommand<Message> command = mock(BotCommand.class);
+        when(registry.find(eq(BotRequestType.MESSAGE), any())).thenReturn(command);
+
+        Bot bot = mock(Bot.class);
+        when(bot.config()).thenReturn(config);
+        when(bot.registry()).thenReturn(registry);
+        when(bot.token()).thenReturn("token");
+
+        BotRequestConverter<Message> converter = mock(BotRequestConverter.class);
+        BotUserProvider provider = mock(BotUserProvider.class);
+        BotUserInfo userInfo = mock(BotUserInfo.class);
+        when(provider.resolve(any())).thenReturn(userInfo);
+
+        Update update = new Update();
+        Message msg = new Message();
+        update.setMessage(msg);
+        when(converter.convert(update, BotRequestType.MESSAGE)).thenReturn(msg);
+
+        when(command.handle(any())).thenReturn(new BotResponse());
+
+        BotAdapterImpl adapter = new BotAdapterImpl(bot, (BotRequestConverter) converter, provider);
+        adapter.handle(update);
+
+        verify(interceptor).preHandle(update);
+        verify(interceptor).postHandle(update);
+        verify(interceptor).afterCompletion(eq(update), any());
+        assertNull(BotRequestHolder.getUpdate());
+        assertNull(BotRequestHolder.getSender());
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotCommandRegistryOrderTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotCommandRegistryOrderTest.java
@@ -1,0 +1,43 @@
+import io.lonmstalker.core.BotCommand;
+import io.lonmstalker.core.BotRequest;
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.bot.BotCommandRegistry;
+import io.lonmstalker.core.bot.BotCommandRegistryImpl;
+import io.lonmstalker.core.matching.AlwaysMatch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.Message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("BotCommandRegistryImpl")
+class BotCommandRegistryOrderTest {
+    @Test
+    @DisplayName("возвращает команду с меньшим order")
+    void shouldReturnCommandWithLowerOrderFirst() {
+        BotCommandRegistry registry = new BotCommandRegistryImpl();
+
+        BotCommand<BotApiObject> first = new TestCmd(1);
+        BotCommand<BotApiObject> second = new TestCmd(0);
+        registry.add(first);
+        registry.add(second);
+
+        assertEquals(second, registry.find(BotRequestType.MESSAGE, new Message()));
+    }
+
+    static class TestCmd implements BotCommand<BotApiObject> {
+        private final int ord;
+        TestCmd(int ord) { this.ord = ord; }
+        @Override
+        public BotResponse handle(BotRequest<BotApiObject> request) { return new BotResponse(); }
+        @Override
+        public BotRequestType type() { return BotRequestType.MESSAGE; }
+        @Override
+        public AlwaysMatch<BotApiObject> matcher() { return new AlwaysMatch<>(); }
+        @Override
+        public int order() { return ord; }
+    }
+
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotDataSourceFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotDataSourceFactoryTest.java
@@ -1,0 +1,49 @@
+import io.lonmstalker.core.ProxyType;
+import io.lonmstalker.core.bot.BotConfig;
+import io.lonmstalker.core.bot.BotDataSourceFactory;
+import io.lonmstalker.core.utils.TokenCipher;
+import io.lonmstalker.core.utils.TokenCipherImpl;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BotDataSourceFactory")
+class BotDataSourceFactoryTest {
+    DataSource ds;
+    TokenCipher cipher = new TokenCipherImpl("1234567890123456");
+
+    @BeforeEach
+    void init() throws Exception {
+        ds = JdbcConnectionPool.create("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1", "sa", "");
+        try (Connection c = ds.getConnection(); Statement st = c.createStatement()) {
+            st.execute("CREATE TABLE bot_settings (id INT PRIMARY KEY, token VARCHAR(512), proxy_host VARCHAR(255), proxy_port INT, proxy_type SMALLINT, updates_timeout INT, updates_limit INT, max_threads INT)");
+            String enc = cipher.encrypt("token");
+            st.executeUpdate("INSERT INTO bot_settings (id, token) VALUES (1, '" + enc + "')");
+        }
+    }
+
+    @AfterEach
+    void close() throws Exception {
+        ((JdbcConnectionPool) ds).dispose();
+    }
+
+    @Test
+    @DisplayName("загружает конфигурацию из базы")
+    void loadData() {
+        BotDataSourceFactory.BotData data = BotDataSourceFactory.INSTANCE.load(ds,1,cipher);
+        assertEquals("token", data.token());
+        BotConfig cfg = data.config();
+        assertEquals(ProxyType.HTTP, cfg.getProxyType());
+        assertEquals(1, cfg.getMaxThreads());
+        assertEquals(0, cfg.getGetUpdatesTimeout());
+        assertEquals(100, cfg.getGetUpdatesLimit());
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotFactoryTest.java
@@ -1,0 +1,57 @@
+import io.lonmstalker.core.bot.*;
+import io.lonmstalker.core.utils.TokenCipherImpl;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BotFactory")
+class BotFactoryTest {
+    DataSource ds;
+
+    @BeforeEach
+    void init() throws Exception {
+        ds = JdbcConnectionPool.create("jdbc:h2:mem:bot;DB_CLOSE_DELAY=-1", "sa", "");
+        try (Connection c = ds.getConnection(); Statement st = c.createStatement()) {
+            st.execute("CREATE TABLE bot_settings (id INT PRIMARY KEY, token VARCHAR(512), proxy_host VARCHAR(255), proxy_port INT, proxy_type SMALLINT, updates_timeout INT, updates_limit INT, max_threads INT)");
+            String token = new TokenCipherImpl("1234567890123456").encrypt("tok");
+            st.executeUpdate("INSERT INTO bot_settings (id, token) VALUES (5, '" + token + "')");
+        }
+    }
+
+    @AfterEach
+    void close() {
+        ((JdbcConnectionPool) ds).dispose();
+    }
+
+    @Test
+    @DisplayName("создаёт бота по токену")
+    void createFromToken() {
+        Bot bot = BotFactory.INSTANCE.from("tok", new BotConfig(), update -> null);
+        assertNotNull(bot);
+        assertEquals("tok", bot.token());
+    }
+
+    @Test
+    @DisplayName("создаёт бота с вебхуком")
+    void createWithWebhook() {
+        Bot bot = BotFactory.INSTANCE.from("tok", new BotConfig(), update -> null, new SetWebhook());
+        assertNotNull(bot);
+    }
+
+    @Test
+    @DisplayName("создаёт бота из DataSource")
+    void createFromDataSource() {
+        BotDataSourceConfig cfg = BotDataSourceConfig.builder().dataSource(ds).build();
+        Bot bot = BotFactory.INSTANCE.from(5, cfg, update -> null, new TokenCipherImpl("1234567890123456"));
+        assertEquals("tok", bot.token());
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotImplExtraTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotImplExtraTest.java
@@ -1,0 +1,69 @@
+import io.lonmstalker.core.bot.*;
+import io.lonmstalker.core.exception.BotApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.bots.DefaultBotOptions;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BotImpl extra logic")
+class BotImplExtraTest {
+    static class DummySender extends TelegramSender {
+        DummySender() { super(new DefaultBotOptions(), "t"); }
+    }
+
+    @Test
+    @DisplayName("stop до start генерирует исключение")
+    void stopBeforeStartShouldThrow() {
+        BotImpl bot = BotImpl.builder()
+                .id(1)
+                .token("t")
+                .config(new BotConfig())
+                .absSender(new DummySender())
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        assertThrows(BotApiException.class, bot::stop);
+    }
+
+    @Test
+    @DisplayName("stop после start отрабатывает")
+    void stopAfterStartWorks() throws Exception {
+        BotImpl bot = BotImpl.builder()
+                .id(1)
+                .token("t")
+                .config(new BotConfig())
+                .absSender(new DummySender() {
+                    @Override
+                    public <T extends java.io.Serializable, Method extends org.telegram.telegrambots.meta.api.methods.BotApiMethod<T>> T sendApiMethod(Method method) {
+                        User u = new User();
+                        u.setId(2L);
+                        u.setUserName("u");
+                        return (T) u;
+                    }
+                })
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.start();
+        assertDoesNotThrow(bot::stop);
+    }
+
+    @Test
+    @DisplayName("onComplete добавляет действие")
+    void onCompleteAddsAction() throws Exception {
+        BotImpl bot = BotImpl.builder()
+                .id(1)
+                .token("t")
+                .config(new BotConfig())
+                .absSender(new DummySender())
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.onComplete(() -> {});
+        Field f = BotImpl.class.getDeclaredField("completeActions");
+        f.setAccessible(true);
+        var list = (java.util.List<?>) f.get(bot);
+        assertEquals(1, list.size());
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotRequestConverterImplTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotRequestConverterImplTest.java
@@ -1,0 +1,106 @@
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.bot.BotRequestConverterImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BotRequestConverterImpl")
+class BotRequestConverterImplTest {
+    @Test
+    @DisplayName("маппит все типы запросов")
+    void shouldMapAllTypes() {
+        BotRequestConverterImpl conv = new BotRequestConverterImpl();
+        Update u = new Update();
+
+        Message m = new Message();
+        u.setMessage(m);
+        assertEquals(m, conv.convert(u, BotRequestType.MESSAGE));
+
+        u = new Update();
+        Message em = new Message();
+        u.setEditedMessage(em);
+        assertEquals(em, conv.convert(u, BotRequestType.EDITED_MESSAGE));
+
+        u = new Update();
+        Message cp = new Message();
+        u.setChannelPost(cp);
+        assertEquals(cp, conv.convert(u, BotRequestType.CHANNEL_POST));
+
+        u = new Update();
+        Message ecp = new Message();
+        u.setEditedChannelPost(ecp);
+        assertEquals(ecp, conv.convert(u, BotRequestType.EDITED_CHANNEL_POST));
+
+        u = new Update();
+        ShippingQuery sq = new ShippingQuery();
+        u.setShippingQuery(sq);
+        assertEquals(sq, conv.convert(u, BotRequestType.SHIPPING_QUERY));
+
+        u = new Update();
+        PreCheckoutQuery pcq = new PreCheckoutQuery();
+        u.setPreCheckoutQuery(pcq);
+        assertEquals(pcq, conv.convert(u, BotRequestType.PRE_CHECKOUT_QUERY));
+
+        u = new Update();
+        Poll poll = new Poll();
+        u.setPoll(poll);
+        assertEquals(poll, conv.convert(u, BotRequestType.POLL));
+
+        u = new Update();
+        PollAnswer pa = new PollAnswer();
+        u.setPollAnswer(pa);
+        assertEquals(pa, conv.convert(u, BotRequestType.POLL_ANSWER));
+
+        u = new Update();
+        ChatMemberUpdated cmu = new ChatMemberUpdated();
+        u.setChatMember(cmu);
+        assertEquals(cmu, conv.convert(u, BotRequestType.CHAT_MEMBER));
+
+        u = new Update();
+        ChatMemberUpdated mcmu = new ChatMemberUpdated();
+        u.setMyChatMember(mcmu);
+        assertEquals(mcmu, conv.convert(u, BotRequestType.MY_CHAT_MEMBER));
+
+        u = new Update();
+        ChatJoinRequest cjr = new ChatJoinRequest();
+        u.setChatJoinRequest(cjr);
+        assertEquals(cjr, conv.convert(u, BotRequestType.CHAT_JOIN_REQUEST));
+
+        u = new Update();
+        CallbackQuery cq = new CallbackQuery();
+        u.setCallbackQuery(cq);
+        assertEquals(cq, conv.convert(u, BotRequestType.CALLBACK_QUERY));
+
+        u = new Update();
+        InlineQuery iq = new InlineQuery();
+        u.setInlineQuery(iq);
+        assertEquals(iq, conv.convert(u, BotRequestType.INLINE_QUERY));
+
+        u = new Update();
+        ChosenInlineQuery ciq = new ChosenInlineQuery();
+        u.setChosenInlineQuery(ciq);
+        assertEquals(ciq, conv.convert(u, BotRequestType.CHOSEN_INLINE_QUERY));
+
+        u = new Update();
+        MessageReactionUpdated mru = new MessageReactionUpdated();
+        u.setMessageReaction(mru);
+        assertEquals(mru, conv.convert(u, BotRequestType.MESSAGE_REACTION));
+
+        u = new Update();
+        MessageReactionCountUpdated mrcu = new MessageReactionCountUpdated();
+        u.setMessageReactionCount(mrcu);
+        assertEquals(mrcu, conv.convert(u, BotRequestType.MESSAGE_REACTION_COUNT));
+
+        u = new Update();
+        ChatBoostUpdated boost = new ChatBoostUpdated();
+        u.setChatBoost(boost);
+        assertEquals(boost, conv.convert(u, BotRequestType.CHAT_BOOST));
+
+        u = new Update();
+        ChatBoostUpdated removed = new ChatBoostUpdated();
+        u.setRemovedChatBoost(removed);
+        assertEquals(removed, conv.convert(u, BotRequestType.REMOVED_CHAT_BOOST));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotRequestHolderTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotRequestHolderTest.java
@@ -1,0 +1,24 @@
+import io.lonmstalker.core.bot.TelegramSender;
+import io.lonmstalker.core.storage.BotRequestHolder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BotRequestHolder")
+class BotRequestHolderTest {
+    @Test
+    @DisplayName("хранит и очищает значения")
+    void holderStoresAndClearsValues() {
+        Update u = new Update();
+        TelegramSender sender = new TelegramSender(new BotConfig(), "t");
+        BotRequestHolder.setUpdate(u);
+        BotRequestHolder.setSender(sender);
+        assertEquals(u, BotRequestHolder.getUpdate());
+        assertEquals(sender, BotRequestHolder.getSender());
+        BotRequestHolder.clear();
+        assertNull(BotRequestHolder.getUpdate());
+        assertNull(BotRequestHolder.getSender());
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotRequestTypeTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotRequestTypeTest.java
@@ -1,0 +1,15 @@
+import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.exception.BotApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("BotRequestType")
+class BotRequestTypeTest {
+    @Test
+    @DisplayName("checkType бросает исключение при неправильном классе")
+    void checkTypeShouldThrowForWrongClass() {
+        assertThrows(BotApiException.class, () -> BotRequestType.MESSAGE.checkType(String.class));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/CommandMatchersTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/CommandMatchersTest.java
@@ -1,0 +1,76 @@
+import io.lonmstalker.core.matching.*;
+import io.lonmstalker.core.storage.BotRequestHolder;
+import io.lonmstalker.core.user.BotUserInfo;
+import io.lonmstalker.core.user.BotUserProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.interfaces.BotApiObject;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("CommandMatch implementations")
+class CommandMatchersTest {
+    @AfterEach
+    void cleanup() {
+        BotRequestHolder.clear();
+    }
+
+    @Test
+    @DisplayName("MessageTextMatch")
+    void messageTextMatch() {
+        Message msg = new Message();
+        msg.setText("Hello");
+        assertTrue(new MessageTextMatch("Hello").match(msg));
+        assertFalse(new MessageTextMatch("hello").match(msg));
+        assertTrue(new MessageTextMatch("hello", true).match(msg));
+    }
+
+    @Test
+    @DisplayName("MessageContainsMatch")
+    void messageContainsMatch() {
+        Message msg = new Message();
+        msg.setText("Hello world");
+        assertTrue(new MessageContainsMatch("world").match(msg));
+        assertFalse(new MessageContainsMatch("WORLD").match(msg));
+        assertTrue(new MessageContainsMatch("WORLD", true).match(msg));
+    }
+
+    @Test
+    @DisplayName("MessageRegexMatch")
+    void messageRegexMatch() {
+        Message msg = new Message();
+        msg.setText("abc123");
+        assertTrue(new MessageRegexMatch("\\w+\\d+").match(msg));
+    }
+
+    @Test
+    @DisplayName("AlwaysMatch")
+    void alwaysMatch() {
+        Message msg = new Message();
+        assertTrue(new AlwaysMatch<>().match(msg));
+    }
+
+    @Test
+    @DisplayName("UserRoleMatch")
+    void userRoleMatch() {
+        Update update = new Update();
+        BotRequestHolder.setUpdate(update);
+        BotUserInfo info = mock(BotUserInfo.class);
+        when(info.roles()).thenReturn(Set.of("ADMIN"));
+        BotUserProvider provider = mock(BotUserProvider.class);
+        when(provider.resolve(update)).thenReturn(info);
+        CommandMatch<BotApiObject> match = new UserRoleMatch<>(provider, Set.of("ADMIN"));
+        assertTrue(match.match(msg()));
+        assertFalse(new UserRoleMatch<>(provider, Set.of("USER")).match(msg()));
+    }
+
+    private Message msg() {
+        return new Message();
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/LoggingBotInterceptorTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/LoggingBotInterceptorTest.java
@@ -1,0 +1,20 @@
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.interceptor.defaults.LoggingBotInterceptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("LoggingBotInterceptor")
+class LoggingBotInterceptorTest {
+    @Test
+    @DisplayName("вызывает методы без исключений")
+    void shouldRunWithoutExceptions() {
+        LoggingBotInterceptor i = new LoggingBotInterceptor();
+        Update u = new Update();
+        assertDoesNotThrow(() -> i.preHandle(u));
+        assertDoesNotThrow(() -> i.postHandle(u));
+        assertDoesNotThrow(() -> i.afterCompletion(u, new BotResponse()));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/ReceiversTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/ReceiversTest.java
@@ -1,0 +1,44 @@
+import io.lonmstalker.core.BotAdapter;
+import io.lonmstalker.core.bot.BotConfig;
+import io.lonmstalker.core.bot.LongPollingReceiver;
+import io.lonmstalker.core.bot.WebHookReceiver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.send.SendMessage;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.io.Serializable;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Receivers")
+class ReceiversTest {
+    @Test
+    @DisplayName("LongPollingReceiver исполняет метод")
+    void longPollingReceiverShouldExecuteMethod() throws Exception {
+        BotApiMethod<Serializable> method = new SendMessage();
+        BotAdapter adapter = mock(BotAdapter.class);
+        when(adapter.handle(any())).thenReturn(method);
+        class TestReceiver extends LongPollingReceiver {
+            BotApiMethod<?> executed;
+            TestReceiver() { super(new BotConfig(), adapter, "t", null); }
+            @Override
+            public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method m) { executed = m; return null; }
+        }
+        TestReceiver r = new TestReceiver();
+        r.onUpdateReceived(new Update());
+        assertEquals(method, r.executed);
+    }
+
+    @Test
+    @DisplayName("WebHookReceiver обрабатывает ошибки")
+    void webHookReceiverHandlesErrors() {
+        BotAdapter adapter = mock(BotAdapter.class);
+        when(adapter.handle(any())).thenThrow(new RuntimeException("err"));
+        var receiver = new WebHookReceiver(new BotConfig(), adapter, "t", (u,e) -> assertNotNull(e));
+        assertNull(receiver.onWebhookUpdateReceived(new Update()));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/TokenCipherNegativeTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/TokenCipherNegativeTest.java
@@ -1,0 +1,27 @@
+import io.lonmstalker.core.exception.BotApiException;
+import io.lonmstalker.core.utils.TokenCipher;
+import io.lonmstalker.core.utils.TokenCipherImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("TokenCipher negative")
+class TokenCipherNegativeTest {
+    @Test
+    @DisplayName("расшифровка с неверным ключом")
+    void decryptWithWrongKeyShouldFail() {
+        TokenCipher first = new TokenCipherImpl("1234567890123456");
+        String enc = first.encrypt("token");
+        TokenCipher wrong = new TokenCipherImpl("6543210987654321");
+        assertThrows(BotApiException.class, () -> wrong.decrypt(enc));
+    }
+
+    @Test
+    @DisplayName("расшифровка повреждённых данных")
+    void decryptCorruptedDataShouldFail() {
+        TokenCipher cipher = new TokenCipherImpl("1234567890123456");
+        String enc = cipher.encrypt("token") + "xxx";
+        assertThrows(BotApiException.class, () -> cipher.decrypt(enc));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/TokenCipherTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/TokenCipherTest.java
@@ -2,17 +2,38 @@ package io.lonmstalker.core.bot;
 
 import io.lonmstalker.core.utils.TokenCipher;
 import io.lonmstalker.core.utils.TokenCipherImpl;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("TokenCipher positive")
 class TokenCipherTest {
     @Test
+    @DisplayName("шифрование и расшифровка строки")
     void encryptAndDecrypt() {
         TokenCipher cipher = new TokenCipherImpl("1234567890123456");
         String token = "secret";
         String encrypted = cipher.encrypt(token);
         assertNotEquals(token, encrypted);
         assertEquals(token, cipher.decrypt(encrypted));
+    }
+
+    @Test
+    @DisplayName("шифрование/расшифровка через byte[] ключ")
+    void encryptWithBytesKey() {
+        TokenCipher cipher = new TokenCipherImpl("1234567890123456".getBytes());
+        String token = "data";
+        String encrypted = cipher.encrypt(token);
+        assertEquals(token, cipher.decrypt(encrypted));
+    }
+
+    @Test
+    @DisplayName("два вызова encrypt дают разные строки")
+    void encryptProducesDifferentValues() {
+        TokenCipher cipher = new TokenCipherImpl("1234567890123456");
+        String first = cipher.encrypt("tok");
+        String second = cipher.encrypt("tok");
+        assertNotEquals(first, second);
     }
 }


### PR DESCRIPTION
## Summary
- annotate all new tests with `@DisplayName`
- extend `TokenCipherTest` with additional success cases

## Testing
- `mvn -q -pl core test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684d8e45d48c83259d7f2f51bd749446