### PR TITLE
Implement stop actions in BotImpl

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/bot/BotImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotImpl.java
@@ -59,6 +59,22 @@ public class BotImpl implements Bot {
     @Override
     public void stop() {
         checkStarted();
+        for (BotCompleteAction action : completeActions) {
+            try {
+                action.complete();
+            } catch (Exception e) {
+                log.error("Complete action error", e);
+            }
+        }
+        if (absSender instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (Exception e) {
+                log.warn("Error closing sender", e);
+            }
+        }
+        this.user = null;
+        this.setWebhook = null;
     }
 
     @Override

--- a/core/src/test/java/io/lonmstalker/core/bot/BotImplStopActionsTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotImplStopActionsTest.java
@@ -1,0 +1,58 @@
+package io.lonmstalker.core.bot;
+
+import io.lonmstalker.core.exception.BotApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.bots.DefaultBotOptions;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.GetMe;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BotImpl stop actions")
+class BotImplStopActionsTest {
+
+    static class TestSender extends TelegramSender {
+        TestSender() { super(new DefaultBotOptions(), "t"); }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) throws BotApiException {
+            if (method instanceof GetMe) {
+                User u = new User();
+                u.setId(1L);
+                return (T) u;
+            }
+            return null;
+        }
+
+        @Override
+        protected <T extends Serializable, Method extends BotApiMethod<T>> CompletableFuture<T> sendApiMethodAsync(Method method) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Test
+    @DisplayName("stop вызывает зарегистрированные действия")
+    void stopRunsActions() {
+        AtomicInteger counter = new AtomicInteger();
+        BotImpl bot = BotImpl.builder()
+                .id(1)
+                .token("t")
+                .config(new BotConfig())
+                .absSender(new TestSender())
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.onComplete(counter::incrementAndGet);
+        bot.onComplete(counter::incrementAndGet);
+        bot.start();
+        bot.stop();
+        assertEquals(2, counter.get());
+        assertFalse(bot.isStarted());
+    }
+}


### PR DESCRIPTION
## Summary
- implement execution of complete actions in `BotImpl.stop()`
- clear resources and close sender when stopping
- add `BotImplStopActionsTest` verifying that actions run when `stop()` is called

## Testing
- `mvn -q -pl core test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_684da4a4777883259af655c3d14152fc