### PR TITLE
Set username to receiver after GetMe

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/bot/BotImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotImpl.java
@@ -51,6 +51,11 @@ public class BotImpl implements Bot {
         checkNotStarted();
         try {
             this.user = absSender.execute(new GetMe());
+            if (absSender instanceof LongPollingReceiver receiver) {
+                receiver.setUsername(this.user.getUserName());
+            } else if (absSender instanceof WebHookReceiver receiver) {
+                receiver.setUsername(this.user.getUserName());
+            }
         } catch (Exception ex) {
             throw new BotApiException("Error starting bot", ex);
         }

--- a/core/src/test/java/io/lonmstalker/core/bot/BotImplTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotImplTest.java
@@ -6,7 +6,7 @@ import org.telegram.telegrambots.bots.DefaultBotOptions;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.methods.GetMe;
 import org.telegram.telegrambots.meta.api.objects.User;
-import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
+import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
@@ -28,6 +28,52 @@ class BotImplTest {
                 user.setId(123L);
                 user.setUserName("tester");
                 return (T) user;
+            }
+            return null;
+        }
+
+        @Override
+        protected <T extends Serializable, Method extends BotApiMethod<T>> CompletableFuture<T> sendApiMethodAsync(Method method) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class TestLongPollingReceiver extends LongPollingReceiver {
+        TestLongPollingReceiver() {
+            super(new BotConfig(), update -> null, "token", null);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) {
+            if (method instanceof GetMe) {
+                User u = new User();
+                u.setId(1L);
+                u.setUserName("tester");
+                return (T) u;
+            }
+            return null;
+        }
+
+        @Override
+        protected <T extends Serializable, Method extends BotApiMethod<T>> CompletableFuture<T> sendApiMethodAsync(Method method) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    static class TestWebhookReceiver extends WebHookReceiver {
+        TestWebhookReceiver() {
+            super(new BotConfig(), update -> null, "token", null);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) {
+            if (method instanceof GetMe) {
+                User u = new User();
+                u.setId(1L);
+                u.setUserName("tester");
+                return (T) u;
             }
             return null;
         }
@@ -62,5 +108,34 @@ class BotImplTest {
                 .commandRegistry(new BotCommandRegistryImpl())
                 .build();
         assertThrows(BotApiException.class, bot::externalId);
+    }
+
+    @Test
+    void startShouldSetUsernameInLongPollingReceiver() {
+        var receiver = new TestLongPollingReceiver();
+        var bot = BotImpl.builder()
+                .id(1)
+                .token("token")
+                .config(new BotConfig())
+                .absSender(receiver)
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.start();
+        assertEquals("tester", receiver.getBotUsername());
+    }
+
+    @Test
+    void startShouldSetUsernameInWebhookReceiver() {
+        var receiver = new TestWebhookReceiver();
+        var bot = BotImpl.builder()
+                .id(1)
+                .token("token")
+                .config(new BotConfig())
+                .absSender(receiver)
+                .commandRegistry(new BotCommandRegistryImpl())
+                .setWebhook(new SetWebhook())
+                .build();
+        bot.start();
+        assertEquals("tester", receiver.getBotUsername());
     }
 }


### PR DESCRIPTION
## Summary
- set username on `LongPollingReceiver`/`WebHookReceiver` after `GetMe`
- test username is applied to receivers

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684da4a510688325aa4bda0f5bb15518