### PR TITLE
Add ImprovedBotSession

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/bot/BotFactory.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotFactory.java
@@ -3,6 +3,7 @@ package io.lonmstalker.core.bot;
 import io.lonmstalker.core.BotAdapter;
 import io.lonmstalker.core.bot.BotDataSourceFactory.BotData;
 import io.lonmstalker.core.utils.TokenCipher;
+import io.lonmstalker.core.bot.ImprovedBotSession;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -15,11 +16,12 @@ public final class BotFactory {
     public static final BotFactory INSTANCE = new BotFactory();
     private final AtomicLong nextId = new AtomicLong();
 
-    public @NonNull Bot from(@NonNull String token, 
+    public @NonNull Bot from(@NonNull String token,
                              @NonNull BotConfig config,
                              @NonNull BotAdapter adapter) {
         return implBuilder(token, config)
                 .absSender(new LongPollingReceiver(config, adapter, token, config.getGlobalExceptionHandler()))
+                .session(new ImprovedBotSession())
                 .build();
     }
 

--- a/core/src/test/java/io/lonmstalker/core/bot/ImprovedBotSessionStartStopTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/ImprovedBotSessionStartStopTest.java
@@ -1,0 +1,63 @@
+package io.lonmstalker.core.bot;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.GetMe;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.io.Serializable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ImprovedBotSession lifecycle")
+class ImprovedBotSessionStartStopTest {
+
+    static class DummyReceiver extends LongPollingReceiver {
+        DummyReceiver() {
+            super(new BotConfig(), update -> null, "t", null);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) {
+            if (method instanceof GetMe) {
+                User u = new User();
+                u.setId(1L);
+                u.setUserName("tester");
+                return (T) u;
+            }
+            return null;
+        }
+    }
+
+    @Test
+    @DisplayName("session starts and stops")
+    void sessionStartStop() {
+        BotConfig cfg = new BotConfig();
+        DummyReceiver receiver = new DummyReceiver();
+        BotImpl bot = BotImpl.builder()
+                .id(1)
+                .token("t")
+                .config(cfg)
+                .absSender(receiver)
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.start();
+        ImprovedBotSession session = getSession(bot);
+        assertNotNull(session);
+        assertTrue(session.isRunning());
+        bot.stop();
+        assertFalse(session.isRunning());
+    }
+
+    private ImprovedBotSession getSession(BotImpl bot) {
+        try {
+            var f = BotImpl.class.getDeclaredField("session");
+            f.setAccessible(true);
+            return (ImprovedBotSession) f.get(bot);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `ImprovedBotSession` into `BotImpl`
- use `ImprovedBotSession` when building bots in `BotFactory`
- test session lifecycle
- initialize webhooks for webhook bots

## Testing
- `mvn -q -pl core test` *(fails: PluginResolutionException)*
- `mvn -q -DskipTests -pl core package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684da4a63de883258be04041553c7cbc