### PR TITLE
Add file-based user repository

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,7 +57,6 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${h2.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/core/src/main/java/io/lonmstalker/core/user/DefaultBotUserProvider.java
+++ b/core/src/main/java/io/lonmstalker/core/user/DefaultBotUserProvider.java
@@ -1,0 +1,15 @@
+package io.lonmstalker.core.user;
+
+/**
+ * Default {@link BotUserProvider} implementation that stores users in a file DB.
+ */
+public class DefaultBotUserProvider extends DbBotUserProvider {
+
+    public DefaultBotUserProvider() {
+        this("./bot-user-db");
+    }
+
+    public DefaultBotUserProvider(String dbFile) {
+        super(new FileBotUserRepository(dbFile));
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/user/FileBotUserRepository.java
+++ b/core/src/main/java/io/lonmstalker/core/user/FileBotUserRepository.java
@@ -1,0 +1,58 @@
+package io.lonmstalker.core.user;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.sql.*;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * File-based implementation of {@link BotUserRepository} using H2 database.
+ */
+public class FileBotUserRepository implements BotUserRepository {
+    private final Connection connection;
+
+    public FileBotUserRepository(@NonNull String dbFile) {
+        try {
+            this.connection = DriverManager.getConnection("jdbc:h2:file:" + dbFile);
+            try (Statement st = connection.createStatement()) {
+                st.executeUpdate("CREATE TABLE IF NOT EXISTS bot_user(" +
+                        "id BIGINT PRIMARY KEY, chat_id VARCHAR(20), roles VARCHAR)");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public @NonNull BotUserInfo getOrCreate(@NonNull User telegramUser) {
+        long id = telegramUser.getId();
+        try {
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "SELECT chat_id, roles FROM bot_user WHERE id=?")) {
+                ps.setLong(1, id);
+                ResultSet rs = ps.executeQuery();
+                if (rs.next()) {
+                    String chatId = rs.getString(1);
+                    return new DbUserInfo(chatId, Collections.emptySet());
+                }
+            }
+
+            String chatId = String.valueOf(id);
+            try (PreparedStatement ins = connection.prepareStatement(
+                    "INSERT INTO bot_user(id, chat_id, roles) VALUES(?,?,?)")) {
+                ins.setLong(1, id);
+                ins.setString(2, chatId);
+                ins.setString(3, "");
+                ins.executeUpdate();
+            }
+            return new DbUserInfo(chatId, Collections.emptySet());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private record DbUserInfo(@NonNull String chatId,
+                              @NonNull Set<String> roles) implements BotUserInfo {}
+}

--- a/core/src/main/java/io/lonmstalker/core/user/InMemoryBotUserRepository.java
+++ b/core/src/main/java/io/lonmstalker/core/user/InMemoryBotUserRepository.java
@@ -1,0 +1,25 @@
+package io.lonmstalker.core.user;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory implementation of {@link BotUserRepository}.
+ */
+public class InMemoryBotUserRepository implements BotUserRepository {
+    private final Map<Long, BotUserInfo> users = new ConcurrentHashMap<>();
+
+    @Override
+    public @NonNull BotUserInfo getOrCreate(@NonNull User telegramUser) {
+        return users.computeIfAbsent(telegramUser.getId(), id ->
+                new DefaultUserInfo(String.valueOf(id), Set.of()));
+    }
+
+    private record DefaultUserInfo(@NonNull String chatId,
+                                   @NonNull Set<String> roles) implements BotUserInfo {
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/user/DefaultBotUserProviderTest.java
+++ b/core/src/test/java/io/lonmstalker/core/user/DefaultBotUserProviderTest.java
@@ -1,0 +1,32 @@
+package io.lonmstalker.core.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("DefaultBotUserProvider")
+class DefaultBotUserProviderTest {
+
+    @Test
+    @DisplayName("возвращает одного и того же пользователя")
+    void returnsSameUser() {
+        DefaultBotUserProvider provider = new DefaultBotUserProvider("./test-users-provider");
+
+        Update update = new Update();
+        Message msg = new Message();
+        User tgUser = new User();
+        tgUser.setId(2L);
+        msg.setFrom(tgUser);
+        update.setMessage(msg);
+
+        BotUserInfo info1 = provider.resolve(update);
+        BotUserInfo info2 = provider.resolve(update);
+
+        assertEquals(info1.chatId(), info2.chatId());
+        assertEquals("2", info1.chatId());
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/user/FileBotUserRepositoryTest.java
+++ b/core/src/test/java/io/lonmstalker/core/user/FileBotUserRepositoryTest.java
@@ -1,0 +1,24 @@
+package io.lonmstalker.core.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("FileBotUserRepository")
+class FileBotUserRepositoryTest {
+
+    @Test
+    @DisplayName("сохраняет и возвращает пользователя")
+    void saveAndGetUser() {
+        FileBotUserRepository repo = new FileBotUserRepository("./test-users");
+        User tgUser = new User();
+        tgUser.setId(1L);
+
+        BotUserInfo info = repo.getOrCreate(tgUser);
+        assertEquals("1", info.chatId());
+        assertTrue(info.roles().isEmpty());
+        assertEquals(info.chatId(), repo.getOrCreate(tgUser).chatId());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `FileBotUserRepository` backed by H2
- use the file-based repository in `DefaultBotUserProvider`
- update tests for the new repository

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da4a8abcc8325bbdbdcbf80eaa45e