### PR TITLE
Add ImprovedBotSession management

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/bot/BotFactory.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotFactory.java
@@ -3,6 +3,7 @@ package io.lonmstalker.core.bot;
 import io.lonmstalker.core.BotAdapter;
 import io.lonmstalker.core.bot.BotDataSourceFactory.BotData;
 import io.lonmstalker.core.utils.TokenCipher;
+import io.lonmstalker.core.bot.BotSessionImpl;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -20,6 +21,7 @@ public final class BotFactory {
                              @NonNull BotAdapter adapter) {
         return implBuilder(token, config)
                 .absSender(new LongPollingReceiver(config, adapter, token, config.getGlobalExceptionHandler()))
+                .session(new BotSessionImpl())
                 .build();
     }
 

--- a/core/src/main/java/io/lonmstalker/core/exception/BotException.java
+++ b/core/src/main/java/io/lonmstalker/core/exception/BotException.java
@@ -1,0 +1,13 @@
+package io.lonmstalker.core.exception;
+
+public class BotException extends RuntimeException {
+    public BotException(String message) {
+        super(message);
+    }
+    public BotException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public BotException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/utils/UpdateUtils.java
+++ b/core/src/main/java/io/lonmstalker/core/utils/UpdateUtils.java
@@ -1,6 +1,7 @@
 package io.lonmstalker.core.utils;
 
 import io.lonmstalker.core.BotRequestType;
+import io.lonmstalker.core.exception.BotException;
 import lombok.experimental.UtilityClass;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.telegram.telegrambots.meta.api.objects.Update;
@@ -65,13 +66,13 @@ public class UpdateUtils {
             return BotRequestType.REMOVED_CHAT_BOOST;
         }
 
-        throw new IllegalArgumentException("Unknown update type");
+        throw new BotException("Unknown update type");
     }
 
     /**
      * Attempts to extract {@link org.telegram.telegrambots.meta.api.objects.User} from update.
      *
-     * @throws IllegalArgumentException when no user information can be resolved
+     * @throws BotException when no user information can be resolved
      */
     public static @NonNull User getUser(@NonNull Update update) {
         if (update.getMessage() != null && update.getMessage().getFrom() != null) {
@@ -95,6 +96,6 @@ public class UpdateUtils {
         if (update.getChosenInlineQuery() != null) {
             return update.getChosenInlineQuery().getFrom();
         }
-        throw new IllegalArgumentException("User not found in update");
+        throw new BotException("User not found in update");
     }
 }

--- a/core/src/test/java/io/lonmstalker/core/bot/BotImplTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotImplTest.java
@@ -66,6 +66,8 @@ class BotImplTest {
             super(new BotConfig(), update -> null, "token", null);
         }
 
+        boolean webhookSet = false;
+
         @Override
         @SuppressWarnings("unchecked")
         public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) {
@@ -74,6 +76,8 @@ class BotImplTest {
                 u.setId(1L);
                 u.setUserName("tester");
                 return (T) u;
+            } else if (method instanceof SetWebhook) {
+                webhookSet = true;
             }
             return null;
         }
@@ -137,5 +141,6 @@ class BotImplTest {
                 .build();
         bot.start();
         assertEquals("tester", receiver.getBotUsername());
+        assertTrue(receiver.webhookSet);
     }
 }

--- a/core/src/test/java/io/lonmstalker/core/bot/BotSessionLifecycleTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotSessionLifecycleTest.java
@@ -1,0 +1,91 @@
+package io.lonmstalker.core.bot;
+
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.methods.GetMe;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BotSessionLifecycleTest {
+
+    static class DummySession extends BotSessionImpl {
+        boolean started;
+        boolean stopped;
+
+        @Override
+        public synchronized void start() {
+            this.started = true;
+        }
+
+        @Override
+        public synchronized void stop() {
+            this.stopped = true;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return started && !stopped;
+        }
+    }
+
+    static class TestReceiver extends LongPollingReceiver {
+        TestReceiver() {
+            super(new BotConfig(), update -> null, "token", null);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) {
+            if (method instanceof GetMe) {
+                User u = new User();
+                u.setId(1L);
+                u.setUserName("tester");
+                return (T) u;
+            }
+            return null;
+        }
+
+        @Override
+        protected <T extends Serializable, Method extends BotApiMethod<T>> CompletableFuture<T> sendApiMethodAsync(Method method) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    @Test
+    void startStartsSession() {
+        DummySession session = new DummySession();
+        TestReceiver receiver = new TestReceiver();
+        BotImpl bot = BotImpl.builder()
+                .id(1)
+                .token("token")
+                .config(new BotConfig())
+                .absSender(receiver)
+                .session(session)
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.start();
+        assertTrue(session.started);
+    }
+
+    @Test
+    void stopStopsSession() {
+        DummySession session = new DummySession();
+        TestReceiver receiver = new TestReceiver();
+        BotImpl bot = BotImpl.builder()
+                .id(1)
+                .token("token")
+                .config(new BotConfig())
+                .absSender(receiver)
+                .session(session)
+                .commandRegistry(new BotCommandRegistryImpl())
+                .build();
+        bot.start();
+        bot.stop();
+        assertTrue(session.stopped);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ImprovedBotSession field to `BotImpl`
- start/stop ImprovedBotSession in `BotImpl`
- set webhook on WebHookReceiver when starting
- make `BotFactory` create bots with session for long polling
- test ImprovedBotSession lifecycle and webhook setup

## Testing
- `mvn -q -pl core test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684daa2297fc832590c0d4291111d705