### PR TITLE
Add state store support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@
 16. Улучшенная работа с файлами и медиапотоками
 17. Поддерживаются базы данных: H2, PostgreSQL, MySQL, Oracle (без JDBC-драйвера)
 18. Токен бота хранится в зашифрованном виде (ключ для шифрования передаётся в `TokenCipher`)
+
+### Пример использования `StateStore`
+```java
+BotConfig config = new BotConfig();
+config.setStore(new InMemoryStateStore());
+
+Bot bot = BotFactory.INSTANCE.from(token, config, adapter);
+
+// в хендлере
+public void handle(BotRequest<Message> req) {
+    String state = req.botInfo().store().get(req.user().chatId());
+    // ...
+    req.botInfo().store().set(req.user().chatId(), "new-state");
+}
+```

--- a/core/src/main/java/io/lonmstalker/core/BotInfo.java
+++ b/core/src/main/java/io/lonmstalker/core/BotInfo.java
@@ -1,8 +1,10 @@
 package io.lonmstalker.core;
 
 import io.lonmstalker.core.bot.TelegramSender;
+import io.lonmstalker.core.state.StateStore;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public record BotInfo(long internalId,
-                      @NonNull TelegramSender sender) {
+                      @NonNull TelegramSender sender,
+                      @NonNull StateStore store) {
 }

--- a/core/src/main/java/io/lonmstalker/core/bot/BotAdapterImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotAdapterImpl.java
@@ -51,7 +51,7 @@ public class BotAdapterImpl implements BotAdapter {
             BotRequestHolder.setUpdate(update);
             BotRequestHolder.setSender(sender);
             BotUserInfo user = userProvider.resolve(update);
-            BotInfo info = new BotInfo(bot.internalId(), sender);
+            BotInfo info = new BotInfo(bot.internalId(), sender, bot.config().getStore());
             response = command.handle(new BotRequest<>(update.getUpdateId(), data, info, user));
             interceptors.forEach(i -> i.postHandle(update));
             return response != null ? response.getMethod() : null;

--- a/core/src/main/java/io/lonmstalker/core/bot/BotConfig.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotConfig.java
@@ -2,6 +2,8 @@ package io.lonmstalker.core.bot;
 
 import io.lonmstalker.core.exception.BotExceptionHandler;
 import io.lonmstalker.core.interceptor.BotInterceptor;
+import io.lonmstalker.core.state.InMemoryStateStore;
+import io.lonmstalker.core.state.StateStore;
 import lombok.Getter;
 import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -15,4 +17,5 @@ import java.util.List;
 public class BotConfig extends DefaultBotOptions {
     private @Nullable BotExceptionHandler globalExceptionHandler;
     private @NonNull List<BotInterceptor> globalInterceptors = List.of();
+    private @NonNull StateStore store = new InMemoryStateStore();
 }

--- a/core/src/main/java/io/lonmstalker/core/state/InMemoryStateStore.java
+++ b/core/src/main/java/io/lonmstalker/core/state/InMemoryStateStore.java
@@ -1,0 +1,21 @@
+package io.lonmstalker.core.state;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryStateStore implements StateStore {
+    private final Map<String, String> store = new ConcurrentHashMap<>();
+
+    @Override
+    public @Nullable String get(@NonNull String chatId) {
+        return store.get(chatId);
+    }
+
+    @Override
+    public void set(@NonNull String chatId, @NonNull String value) {
+        store.put(chatId, value);
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/state/JdbcStateStore.java
+++ b/core/src/main/java/io/lonmstalker/core/state/JdbcStateStore.java
@@ -1,0 +1,65 @@
+package io.lonmstalker.core.state;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class JdbcStateStore implements StateStore {
+    private static final String CREATE_TABLE =
+            "CREATE TABLE IF NOT EXISTS bot_state(chat_id VARCHAR PRIMARY KEY, value VARCHAR)";
+    private static final String SELECT_QUERY =
+            "SELECT value FROM bot_state WHERE chat_id=?";
+    private static final String UPDATE_QUERY =
+            "UPDATE bot_state SET value=? WHERE chat_id=?";
+    private static final String INSERT_QUERY =
+            "INSERT INTO bot_state(chat_id, value) VALUES(?, ?)";
+
+    private final DataSource dataSource;
+
+    public JdbcStateStore(@NonNull DataSource dataSource) {
+        this.dataSource = dataSource;
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(CREATE_TABLE)) {
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public @Nullable String get(@NonNull String chatId) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(SELECT_QUERY)) {
+            ps.setString(1, chatId);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next() ? rs.getString(1) : null;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void set(@NonNull String chatId, @NonNull String value) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement upd = conn.prepareStatement(UPDATE_QUERY)) {
+            upd.setString(1, value);
+            upd.setString(2, chatId);
+            int updated = upd.executeUpdate();
+            if (updated == 0) {
+                try (PreparedStatement ins = conn.prepareStatement(INSERT_QUERY)) {
+                    ins.setString(1, chatId);
+                    ins.setString(2, value);
+                    ins.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/core/src/main/java/io/lonmstalker/core/state/StateStore.java
+++ b/core/src/main/java/io/lonmstalker/core/state/StateStore.java
@@ -1,0 +1,9 @@
+package io.lonmstalker.core.state;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public interface StateStore {
+    @Nullable String get(@NonNull String chatId);
+    void set(@NonNull String chatId, @NonNull String value);
+}


### PR DESCRIPTION
## Summary
- implement `StateStore` interface with JDBC and in-memory backends
- expose store in `BotConfig` and `BotInfo`
- pass store into command handling
- document store usage in README

## Testing
- `mvn -q test` *(fails: Could not resolve Maven plugin due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_684dc0145b5c83258cf154e23966f96c