### PR TITLE
Implement rate limiting with built‑in backoff

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/bot/BotConfig.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotConfig.java
@@ -2,6 +2,7 @@ package io.lonmstalker.core.bot;
 
 import io.lonmstalker.core.exception.BotExceptionHandler;
 import io.lonmstalker.core.interceptor.BotInterceptor;
+import org.telegram.telegrambots.updatesreceivers.ExponentialBackOff;
 import lombok.Getter;
 import lombok.Setter;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -15,4 +16,9 @@ import java.util.List;
 public class BotConfig extends DefaultBotOptions {
     private @Nullable BotExceptionHandler globalExceptionHandler;
     private @NonNull List<BotInterceptor> globalInterceptors = List.of();
+    private int requestsPerSecond = 30;
+
+    public BotConfig() {
+        setBackOff(new ExponentialBackOff());
+    }
 }

--- a/core/src/main/java/io/lonmstalker/core/bot/RateLimiter.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/RateLimiter.java
@@ -1,0 +1,30 @@
+package io.lonmstalker.core.bot;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+class RateLimiter {
+    private final int permitsPerSecond;
+    private final Semaphore semaphore;
+    private final ScheduledExecutorService scheduler;
+
+    RateLimiter(int permitsPerSecond) {
+        this.permitsPerSecond = permitsPerSecond;
+        this.semaphore = new Semaphore(permitsPerSecond);
+        this.scheduler = Executors.newSingleThreadScheduledExecutor();
+        this.scheduler.scheduleAtFixedRate(this::replenish, 1, 1, TimeUnit.SECONDS);
+    }
+
+    void acquire() throws InterruptedException {
+        semaphore.acquire();
+    }
+
+    private void replenish() {
+        int diff = permitsPerSecond - semaphore.availablePermits();
+        if (diff > 0) {
+            semaphore.release(diff);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use `ExponentialBackOff` from telegram library
- apply backoff in `TelegramSender`
- default backoff initialization in `BotConfig`
- remove custom backoff strategy classes
- wrap async callback errors in `BotApiException`

## Testing
- `mvn -q -pl core -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684dc012ff9c8325a2298339323e617e