### PR TITLE
Fix resource leaks and add RateLimiter tests

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/bot/BotSessionImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotSessionImpl.java
@@ -87,6 +87,10 @@ public class BotSessionImpl implements BotSession {
         if (executor != null && providedExecutor == null) {
             executor.shutdownNow();
         }
+        if (httpClient != null && httpClient.executor().isPresent()) {
+            httpClient.executor().get().shutdownNow();
+        }
+        httpClient = null;
     }
 
     @Override

--- a/core/src/test/java/io/lonmstalker/core/bot/RateLimiterTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/RateLimiterTest.java
@@ -1,0 +1,37 @@
+package io.lonmstalker.core.bot;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimiterTest {
+
+    @Test
+    void permitsPerSecond() throws Exception {
+        RateLimiter limiter = new RateLimiter(2);
+        long start = System.currentTimeMillis();
+        limiter.acquire();
+        limiter.acquire();
+        limiter.acquire();
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed >= 1000);
+        limiter.close();
+        Field field = RateLimiter.class.getDeclaredField("scheduler");
+        field.setAccessible(true);
+        ScheduledExecutorService executor = (ScheduledExecutorService) field.get(limiter);
+        assertTrue(executor.isShutdown());
+    }
+
+    @Test
+    void externalSchedulerNotClosed() {
+        ScheduledExecutorService external = Executors.newSingleThreadScheduledExecutor();
+        RateLimiter limiter = new RateLimiter(1, external);
+        limiter.close();
+        assertFalse(external.isShutdown());
+        external.shutdownNow();
+    }
+}


### PR DESCRIPTION
## Summary
- add shutdown for `RateLimiter`
- let `TelegramSender` implement `AutoCloseable` and close limiter
- close threads and HTTP resources in `BotSessionImpl.stop`
- refactor `BotAdapterImpl.handle` into smaller methods
- test basic rate limiting behaviour
- allow injecting executor for `RateLimiter` and do not shut it down if provided

## Testing
- `mvn -q -pl core test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684de8b40ad08325ad10c1d07a5c0f62