### PR TITLE
Add command response localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 16. Улучшенная работа с файлами и медиапотоками
 17. Поддерживаются базы данных: H2, PostgreSQL, MySQL, Oracle (без JDBC-драйвера)
 18. Токен бота хранится в зашифрованном виде (ключ для шифрования передаётся в `TokenCipher`)
+19. Поддержка локализации ответов команд бота
 
 ## Пример использования
 
@@ -36,6 +37,8 @@ public class EchoCommands {
 Bot bot = BotFactory.INSTANCE.from(token, new BotConfig(), new BotAdapterImpl(bot, converter, provider), "com.example.bot");
 bot.start();
 ```
+
+Внутри обработчиков команд можно использовать `request.localizer().get("key")` для получения локализованного текста.
 
 ### Пример использования `StateStore`
 ```java

--- a/core/src/main/java/io/lonmstalker/core/BotRequest.java
+++ b/core/src/main/java/io/lonmstalker/core/BotRequest.java
@@ -3,8 +3,11 @@ package io.lonmstalker.core;
 import io.lonmstalker.core.user.BotUserInfo;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
+import io.lonmstalker.core.i18n.MessageLocalizer;
+
 public record BotRequest<T>(int updateId,
                             @NonNull T data,
                             @NonNull BotInfo botInfo,
-                            @NonNull BotUserInfo user) {
+                            @NonNull BotUserInfo user,
+                            @NonNull MessageLocalizer localizer) {
 }

--- a/core/src/main/java/io/lonmstalker/core/bot/BotAdapterImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotAdapterImpl.java
@@ -68,7 +68,8 @@ public class BotAdapterImpl implements BotAdapter {
             BotRequestHolder.setSender(sender);
             BotUserInfo user = userProvider.resolve(update);
             BotInfo info = new BotInfo(bot.internalId(), sender, bot.config().getStore());
-            return command.handle(new BotRequest<>(update.getUpdateId(), data, info, user));
+            var localizer = new io.lonmstalker.core.i18n.MessageLocalizer(bot.config().getLocale());
+            return command.handle(new BotRequest<>(update.getUpdateId(), data, info, user, localizer));
         } finally {
             try {
                 sender.close();

--- a/core/src/main/java/io/lonmstalker/core/bot/BotConfig.java
+++ b/core/src/main/java/io/lonmstalker/core/bot/BotConfig.java
@@ -11,6 +11,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.telegram.telegrambots.bots.DefaultBotOptions;
 
 import java.util.List;
+import java.util.Locale;
 
 @Setter
 @Getter
@@ -20,6 +21,7 @@ public class BotConfig extends DefaultBotOptions {
     private @NonNull StateStore store = new InMemoryStateStore();
     private @NonNull String botPattern = "";
     private int requestsPerSecond = 30;
+    private @NonNull Locale locale = Locale.getDefault();
 
     public BotConfig() {
         setBackOff(new ExponentialBackOff());

--- a/core/src/main/java/io/lonmstalker/core/i18n/MessageLocalizer.java
+++ b/core/src/main/java/io/lonmstalker/core/i18n/MessageLocalizer.java
@@ -1,0 +1,28 @@
+package io.lonmstalker.core.i18n;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+public class MessageLocalizer {
+
+    private final ResourceBundle bundle;
+
+    public MessageLocalizer() {
+        this(Locale.getDefault());
+    }
+
+    public MessageLocalizer(@NonNull Locale locale) {
+        this.bundle = ResourceBundle.getBundle("i18n.messages", locale);
+    }
+
+    public @NonNull String get(@NonNull String key) {
+        try {
+            return this.bundle.getString(key);
+        } catch (MissingResourceException ex) {
+            return key;
+        }
+    }
+}

--- a/core/src/main/resources/i18n/messages.properties
+++ b/core/src/main/resources/i18n/messages.properties
@@ -1,0 +1,1 @@
+command.ping.response=Pong

--- a/core/src/main/resources/i18n/messages_ru.properties
+++ b/core/src/main/resources/i18n/messages_ru.properties
@@ -1,0 +1,1 @@
+command.ping.response=Понг

--- a/core/src/test/java/io/lonmstalker/core/i18n/MessageLocalizerTest.java
+++ b/core/src/test/java/io/lonmstalker/core/i18n/MessageLocalizerTest.java
@@ -1,0 +1,16 @@
+package io.lonmstalker.core.i18n;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+public class MessageLocalizerTest {
+
+    @Test
+    void russianLocale() {
+        MessageLocalizer localizer = new MessageLocalizer(new Locale("ru"));
+        assertEquals("Понг", localizer.get("command.ping.response"));
+    }
+}


### PR DESCRIPTION
## Summary
- localize command responses using `MessageLocalizer`
- provide localizer through `BotRequest`
- revert cipher error localization
- document localized responses in README

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684df45e68488325bd660bf25407d133