### PR TITLE
Implement prioritized locale selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Bot bot = BotFactory.INSTANCE.from(token, new BotConfig(), new BotAdapterImpl(bo
 bot.start();
 ```
 
-Внутри обработчиков команд можно использовать `request.localizer().get("key")` для получения локализованного текста.
+Внутри обработчиков команд можно использовать `request.botInfo().localizer().get("key")` для получения локализованного текста.
 
 ### Пример использования `StateStore`
 ```java

--- a/core/src/main/java/io/lonmstalker/core/BotInfo.java
+++ b/core/src/main/java/io/lonmstalker/core/BotInfo.java
@@ -1,10 +1,12 @@
 package io.lonmstalker.core;
 
 import io.lonmstalker.core.bot.TelegramSender;
+import io.lonmstalker.core.i18n.MessageLocalizer;
 import io.lonmstalker.core.state.StateStore;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public record BotInfo(long internalId,
                       @NonNull StateStore store,
-                      @NonNull TelegramSender sender) {
+                      @NonNull TelegramSender sender,
+                      @NonNull MessageLocalizer localizer) {
 }

--- a/core/src/main/java/io/lonmstalker/core/user/BotUserInfo.java
+++ b/core/src/main/java/io/lonmstalker/core/user/BotUserInfo.java
@@ -1,8 +1,10 @@
 package io.lonmstalker.core.user;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Set;
+import java.util.Locale;
 
 public interface BotUserInfo {
 
@@ -11,4 +13,9 @@ public interface BotUserInfo {
 
     @NonNull
     Set<String> roles();
+
+    @Nullable
+    default Locale locale() {
+        return null;
+    }
 }

--- a/core/src/test/java/io/lonmstalker/core/matching/MatchersTest.java
+++ b/core/src/test/java/io/lonmstalker/core/matching/MatchersTest.java
@@ -57,6 +57,7 @@ public class MatchersTest {
         BotUserProvider provider = u -> new BotUserInfo() {
             @Override public String chatId() { return "1"; }
             @Override public Set<String> roles() { return Set.of("ADMIN"); }
+            @Override public java.util.Locale locale() { return null; }
         };
         User tgUser = new User();
         tgUser.setId(1L);

--- a/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleBotCommandsTest.java
+++ b/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleBotCommandsTest.java
@@ -136,7 +136,8 @@ class SimpleBotCommandsTest {
         assertNotNull(command);
 
         var user = provider.resolve(update);
-        BotInfo info = new BotInfo(1L, new InMemoryStateStore(), new TestSender());
+        var localizer = new io.lonmstalker.core.i18n.MessageLocalizer(java.util.Locale.getDefault());
+        BotInfo info = new BotInfo(1L, new InMemoryStateStore(), new TestSender(), localizer);
         BotResponse resp = command.handle(new BotRequest<>(1, data, info, user));
 
         assertNotNull(resp);


### PR DESCRIPTION
## Summary
- add MessageLocalizer into `BotInfo`
- remove `MessageLocalizer` from `BotRequest`
- choose locale in `BotAdapterImpl` from user info, telegram user or bot config
- update usage in tests and README

## Testing
- `mvn test` *(failed: Could not transfer artifact org.apache.maven.plugins:maven-compiler-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc45249883259cb10881f53f8e99