### PR TITLE
Update stdoutDev to use composite SpanExporter

### DIFF
--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>opentelemetry-sdk</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/observability/src/main/java/io/lonmstaler/observability/impl/OTelTracer.java
+++ b/observability/src/main/java/io/lonmstaler/observability/impl/OTelTracer.java
@@ -5,8 +5,10 @@ import io.lonmstaler.observability.Tracer;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TracerProvider;
+import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public final class OTelTracer implements Tracer {
     private final io.opentelemetry.api.trace.Tracer tracer;
@@ -37,8 +39,9 @@ public final class OTelTracer implements Tracer {
     }
 
     public static OTelTracer stdoutDev() {
+        SpanExporter exporter = SpanExporter.composite(new LoggingSpanExporter());
         SdkTracerProvider provider = SdkTracerProvider.builder()
-                .addSpanProcessor(SimpleSpanProcessor.create(MultiSpanExporter.create()))
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
                 .build();
         return new OTelTracer(provider, "tg-bot");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
                 <version>${opentelemetry.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-exporter-logging</artifactId>
+                <version>${opentelemetry.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback.version}</version>


### PR DESCRIPTION
## Summary
- update `OTelTracer.stdoutDev` to use `SpanExporter.composite`
- add logging exporter dependency

## Testing
- `mvn -q -DskipTests install` *(fails: Could not transfer artifact maven-compiler-plugin due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684e9d5305d88325a334fa2399780e3e