### PR TITLE
Fix missing metrics dependencies

### DIFF
--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -40,5 +40,10 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>${prometheus.version}</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Summary
- fix missing Prometheus httpserver dependency for metrics

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ea0408a8c83258c7e5558c131d03f