### PR TITLE
Integrate spotless formatting

### DIFF
--- a/core/src/main/java/io/lonmstalker/core/utils/TokenCipherImpl.java
+++ b/core/src/main/java/io/lonmstalker/core/utils/TokenCipherImpl.java
@@ -34,10 +34,15 @@ public class TokenCipherImpl implements TokenCipher {
     public @NonNull String encrypt(@NonNull String token) {
         try {
             byte[] iv = new byte[IV_LENGTH];
+
             new SecureRandom().nextBytes(iv);
+
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+
             cipher.init(Cipher.ENCRYPT_MODE, this.key, new GCMParameterSpec(TAG_LENGTH, iv));
+
             byte[] encrypted = cipher.doFinal(token.getBytes(StandardCharsets.UTF_8));
+
             byte[] result = new byte[IV_LENGTH + encrypted.length];
             System.arraycopy(iv, 0, result, 0, IV_LENGTH);
             System.arraycopy(encrypted, 0, result, IV_LENGTH, encrypted.length);
@@ -51,11 +56,17 @@ public class TokenCipherImpl implements TokenCipher {
     public @NonNull String decrypt(@NonNull String cipherText) {
         try {
             byte[] decoded = Base64.getDecoder().decode(cipherText);
+
             byte[] iv = Arrays.copyOfRange(decoded, 0, IV_LENGTH);
+
             byte[] data = Arrays.copyOfRange(decoded, IV_LENGTH, decoded.length);
+
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+
             cipher.init(Cipher.DECRYPT_MODE, this.key, new GCMParameterSpec(TAG_LENGTH, iv));
+
             byte[] decrypted = cipher.doFinal(data);
+
             return new String(decrypted, StandardCharsets.UTF_8);
         } catch (GeneralSecurityException ex) {
             throw new BotApiException("Unable to decrypt token", ex);

--- a/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleBotApplication.java
+++ b/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleBotApplication.java
@@ -10,6 +10,7 @@ public class SimpleBotApplication {
     public static void main(String[] args) {
         BotConfig config = new BotConfig();
         BotAdapter adapter = update -> null; // actual logic handled via annotations
+
         Bot bot = BotFactory.INSTANCE.from("TOKEN", config, adapter, "io.lonmstalker.examples.simplebot");
         bot.start();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <checkerframework.version>3.49.4</checkerframework.version>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <checkstyle-maven-plugin.version>3.6.0</checkstyle-maven-plugin.version>
+        <spotless-maven-plugin.version>2.45.0</spotless-maven-plugin.version>
 
         <!-- TEST -->
         <h2.version>2.3.232</h2.version>
@@ -193,6 +194,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless-maven-plugin.version}</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat />
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                            <goal>apply</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- integrate Spotless plugin using Google Java Format
- format token cipher methods with blank lines for clarity
- add spacing in the simple bot example

## Testing
- `mvn -q -DskipTests=true package` *(fails: Plugin com.diffplug.spotless:spotless-maven-plugin:2.45.0 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ea499a27c8325b51f74ee07d29721