### PR TITLE
Add readable negative tests and observability checks

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/core/src/test/java/io/lonmstalker/core/args/ConvertersTest.java
+++ b/core/src/test/java/io/lonmstalker/core/args/ConvertersTest.java
@@ -1,0 +1,17 @@
+package io.lonmstalker.core.args;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.lonmstalker.core.exception.BotApiException;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+public class ConvertersTest {
+    @Test
+    void unsupported_number_converter() {
+        var converter = Converters.getByType(BigDecimal.class);
+        assertThrows(BotApiException.class,
+                () -> converter.convert("1", new Context(null, null)));
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/bot/BotCommandRegistryImplTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotCommandRegistryImplTest.java
@@ -1,6 +1,6 @@
 package io.lonmstalker.core.bot;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.lonmstalker.core.BotCommand;
 import io.lonmstalker.core.BotRequest;
@@ -10,14 +10,17 @@ import io.lonmstalker.core.matching.CommandMatch;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.Test;
 import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import io.lonmstalker.core.exception.BotApiException;
 
 class BotCommandRegistryImplTest {
 
     @Test
-    void addAndFindCommands() {
+    void add_and_find_commands() {
         BotCommandRegistryImpl registry = new BotCommandRegistryImpl();
         BotCommand<Message> first = new TestCommand(1);
         BotCommand<Message> second = new TestCommand(2);
+
         registry.add(first);
         registry.add(second);
 
@@ -26,13 +29,36 @@ class BotCommandRegistryImplTest {
         assertEquals(first, found);
     }
 
+    @Test
+    void find_wrong_type_throws() {
+        BotCommandRegistryImpl registry = new BotCommandRegistryImpl();
+        registry.add(new TestCommand(1));
+
+        Update update = new Update();
+        assertThrows(BotApiException.class,
+                () -> registry.find(BotRequestType.MESSAGE, "", update));
+    }
+
     private static class TestCommand implements BotCommand<Message> {
         private final int order;
-        TestCommand(int order) {this.order = order;}
-        @Override public BotResponse handle(@NonNull BotRequest<Message> request) {return null;}
-        @Override public @NonNull BotRequestType type() {return BotRequestType.MESSAGE;}
-        @Override public @NonNull CommandMatch<Message> matcher() {return data -> true;}
-        @Override public int order() {return order;}
-        @Override public @NonNull String botGroup() {return "";}
+
+        TestCommand(int order) {
+            this.order = order;
+        }
+
+        @Override
+        public BotResponse handle(@NonNull BotRequest<Message> request) { return null; }
+
+        @Override
+        public @NonNull BotRequestType type() { return BotRequestType.MESSAGE; }
+
+        @Override
+        public @NonNull CommandMatch<Message> matcher() { return data -> true; }
+
+        @Override
+        public int order() { return order; }
+
+        @Override
+        public @NonNull String botGroup() { return ""; }
     }
 }

--- a/core/src/test/java/io/lonmstalker/core/bot/BotDataSourceFactoryTest.java
+++ b/core/src/test/java/io/lonmstalker/core/bot/BotDataSourceFactoryTest.java
@@ -2,6 +2,7 @@ package io.lonmstalker.core.bot;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.lonmstalker.core.exception.BotApiException;
 import io.lonmstalker.core.utils.TokenCipherImpl;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,21 +20,47 @@ public class BotDataSourceFactoryTest {
         JdbcDataSource h2 = new JdbcDataSource();
         h2.setURL("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1");
         ds = h2;
-        try (Connection c = ds.getConnection(); Statement st = c.createStatement()) {
-            st.executeUpdate("CREATE TABLE bot_settings (id INT PRIMARY KEY, token VARCHAR(255), proxy_host VARCHAR(255), proxy_port INT, proxy_type INT, max_threads INT, updates_timeout INT, updates_limit INT, bot_pattern VARCHAR(255))");
+        try (Connection c = ds.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate(
+                    "CREATE TABLE bot_settings (id INT PRIMARY KEY, token VARCHAR(255), " +
+                            "proxy_host VARCHAR(255), proxy_port INT, proxy_type INT, " +
+                            "max_threads INT, updates_timeout INT, updates_limit INT, bot_pattern VARCHAR(255))");
         }
     }
 
     @Test
-    void loadData() throws Exception {
+    void load_data() throws Exception {
         var cipher = new TokenCipherImpl("secretkey123456");
         String enc = cipher.encrypt("TEST_TOKEN");
-        try (Connection c = ds.getConnection(); Statement st = c.createStatement()) {
+        try (Connection c = ds.getConnection();
+             Statement st = c.createStatement()) {
             st.executeUpdate("INSERT INTO bot_settings VALUES (1, '" + enc + "', NULL, NULL, 0, 1, 0, 100, '')");
         }
+
         var data = BotDataSourceFactory.INSTANCE.load(ds, 1, cipher);
         assertEquals("TEST_TOKEN", data.token());
         assertEquals(1, data.config().getMaxThreads());
         assertEquals(0, data.config().getGetUpdatesTimeout());
+    }
+
+    @Test
+    void bot_not_found_throws() {
+        var cipher = new TokenCipherImpl("secretkey123456");
+        assertThrows(BotApiException.class,
+                () -> BotDataSourceFactory.INSTANCE.load(ds, 99, cipher));
+    }
+
+    @Test
+    void empty_token_throws() throws Exception {
+        var cipher = new TokenCipherImpl("secretkey123456");
+        String enc = cipher.encrypt("");
+        try (Connection c = ds.getConnection();
+             Statement st = c.createStatement()) {
+            st.executeUpdate("INSERT INTO bot_settings VALUES (2, '" + enc + "', NULL, NULL, 0, 1, 0, 100, '')");
+        }
+
+        assertThrows(BotApiException.class,
+                () -> BotDataSourceFactory.INSTANCE.load(ds, 2, cipher));
     }
 }

--- a/core/src/test/java/io/lonmstalker/core/interceptor/LoggingBotInterceptorTest.java
+++ b/core/src/test/java/io/lonmstalker/core/interceptor/LoggingBotInterceptorTest.java
@@ -1,0 +1,47 @@
+package io.lonmstalker.core.interceptor;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.lonmstalker.core.BotResponse;
+import io.lonmstalker.core.interceptor.defaults.LoggingBotInterceptor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+import org.telegram.telegrambots.meta.api.objects.User;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LoggingBotInterceptorTest {
+    private final Logger logger = (Logger) LoggerFactory.getLogger(LoggingBotInterceptor.class);
+    private final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(appender);
+    }
+
+    @Test
+    void logs_user_and_message_id_on_error() {
+        appender.start();
+        logger.addAppender(appender);
+        LoggingBotInterceptor interceptor = new LoggingBotInterceptor();
+        Update update = new Update();
+        Message msg = new Message();
+        msg.setMessageId(5);
+        User user = new User();
+        user.setId(10L);
+        msg.setFrom(user);
+        update.setMessage(msg);
+        interceptor.afterCompletion(update, (BotResponse) null, new RuntimeException("boom"));
+        assertFalse(appender.list.isEmpty());
+        ILoggingEvent event = appender.list.get(0);
+        assertEquals(Level.DEBUG, event.getLevel());
+        Update logged = (Update) event.getArgumentArray()[0];
+        assertEquals(5, logged.getMessage().getMessageId());
+        assertEquals(10L, logged.getMessage().getFrom().getId());
+    }
+}

--- a/core/src/test/java/io/lonmstalker/core/utils/TokenCipherImplTest.java
+++ b/core/src/test/java/io/lonmstalker/core/utils/TokenCipherImplTest.java
@@ -1,19 +1,25 @@
 package io.lonmstalker.core.utils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
+import io.lonmstalker.core.exception.BotApiException;
 
 public class TokenCipherImplTest {
 
     @Test
-    void encryptDecryptRoundtrip() {
+    void encrypt_decrypt_roundtrip() {
         var cipher = new TokenCipherImpl("secretkey123456");
         var original = "myToken";
         var encrypted = cipher.encrypt(original);
         assertNotEquals(original, encrypted, "encrypted text should differ");
         var decrypted = cipher.decrypt(encrypted);
         assertEquals(original, decrypted);
+    }
+
+    @Test
+    void decrypt_invalid_data_throws() {
+        var cipher = new TokenCipherImpl("secretkey123456");
+        assertThrows(BotApiException.class, () -> cipher.decrypt("boom"));
     }
 }

--- a/observability/pom.xml
+++ b/observability/pom.xml
@@ -45,5 +45,21 @@
             <artifactId>simpleclient_httpserver</artifactId>
             <version>${http-simple-client.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/observability/src/test/java/io/lonmstaler/observability/ObservabilityInterceptorTest.java
+++ b/observability/src/test/java/io/lonmstaler/observability/ObservabilityInterceptorTest.java
@@ -1,0 +1,78 @@
+package io.lonmstaler.observability;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.telegram.telegrambots.meta.api.objects.Message;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class ObservabilityInterceptorTest {
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+    private MetricsCollector metrics;
+    private Tracer tracer;
+    private Timer timer;
+    private Counter counter;
+    private Span span;
+    private ObservabilityInterceptor interceptor;
+
+    @AfterEach
+    void clear() {
+        MDC.clear();
+    }
+
+    @BeforeEach
+    void init() {
+        metrics = mock(MetricsCollector.class);
+        tracer = mock(Tracer.class);
+        timer = mock(Timer.class);
+        counter = mock(Counter.class);
+        span = mock(Span.class);
+
+        when(metrics.registry()).thenReturn(registry);
+        when(metrics.timer(anyString(), any())).thenReturn(timer);
+        when(metrics.counter(anyString(), any())).thenReturn(counter);
+        when(tracer.start(anyString(), any(Attributes.class))).thenReturn(span);
+
+        interceptor = new ObservabilityInterceptor(metrics, tracer);
+    }
+
+    private Update createUpdate(int id) {
+        Update update = new Update();
+        update.setUpdateId(id);
+        update.setMessage(new Message());
+        return update;
+    }
+
+    @Test
+    void span_and_metrics_on_success() {
+        Update update = createUpdate(1);
+        interceptor.preHandle(update);
+        assertEquals("1", MDC.get("updateId"));
+        interceptor.afterCompletion(update, null, null);
+        verify(tracer).start(eq("update"), any(Attributes.class));
+        verify(span).close();
+        verify(metrics, atLeastOnce()).counter(eq("updates_total"), any());
+        verify(metrics).timer(eq("update_latency_ms"), any());
+        assertNull(MDC.get("updateId"));
+    }
+
+    @Test
+    void error_metrics_and_span() {
+        Update update = createUpdate(2);
+        interceptor.preHandle(update);
+        RuntimeException ex = new RuntimeException("boom");
+        interceptor.afterCompletion(update, null, ex);
+        verify(span).setError(ex);
+        verify(counter, atLeastOnce()).increment();
+        verify(metrics).timer(eq("update_latency_ms"), any());
+    }
+}


### PR DESCRIPTION
## Summary
- refactor tests for clarity
- verify logback with ListAppender
- unify naming style in tests
- simplify ObservabilityInterceptor test setup

## Testing
- `mvn -q -DskipTests=false test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684ea49be78c8325b8ccd8752f76decb