### PR TITLE
Fix metrics endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ public void quiz(BotRequest<Message> req) {
 
 ### 3 — Observability за 30 секунд
 ```java
-var metrics = MicrometerCollector.prometheus(9180);   // /metrics
+var metrics = MicrometerCollector.prometheus(9180);   // /prometheus
 var tracer  = OTelTracer.stdoutDev();                 // спаны в лог
 
 BotConfig cfg = BotConfig.builder()


### PR DESCRIPTION
## Summary
- correct README to show `/prometheus` endpoint

## Testing
- `mvn -q test` *(fails: Could not resolve com.diffplug.spotless:spotless-maven-plugin:2.44.5)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2f94fcc83259c742e601663e724