### PR TITLE
Fix minimal echo bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ public class EchoCommands {
 Bot bot = BotFactory.INSTANCE.from(
         token,
         BotConfig.builder().build(),
-        new BotAdapterImpl(bot, converter, provider),
+        update -> null,                       // вся логика в аннотированных хендлерах
         "com.example.bot");
 bot.start();          // smart Webhook ↔︎ Polling
 


### PR DESCRIPTION
## Summary
- fix adapter creation in minimal echo-bot snippet in README

## Testing
- `mvn -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2f389fc8325ad280396afae75ef