### PR TITLE
Fix test package path in observability module

### DIFF
--- a/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
+++ b/observability/src/test/java/io/lonmstalker/observability/ObservabilityInterceptorTest.java
@@ -1,4 +1,4 @@
-package io.lonmstaler.observability;
+package io.lonmstalker.observability;
 
 import io.lonmstalker.observability.MetricsCollector;
 import io.lonmstalker.observability.ObservabilityInterceptor;


### PR DESCRIPTION
## Summary
- move `ObservabilityInterceptorTest` into the correct folder
- fix the package name of the test class

## Testing
- `mvn test` *(fails: Plugin resolution failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2ff44fc83258405ef41bf2c393d