### PR TITLE
Improve SimpleRoleProvider user resolution

### DIFF
--- a/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleRoleProvider.java
+++ b/examples/simple-bot/src/main/java/io/lonmstalker/examples/simplebot/SimpleRoleProvider.java
@@ -13,13 +13,16 @@ public class SimpleRoleProvider implements BotUserProvider {
 
     @Override
     public @NonNull BotUserInfo resolve(Update update) {
-        User user = update.getMessage() != null
-                ? update.getMessage().getFrom()
-                : update.getCallbackQuery() != null
-                ? update.getCallbackQuery().getFrom()
-                : update.getInlineQuery().getFrom();
+        User user = null;
+        if (update.getMessage() != null) {
+            user = update.getMessage().getFrom();
+        } else if (update.getCallbackQuery() != null) {
+            user = update.getCallbackQuery().getFrom();
+        } else if (update.getInlineQuery() != null) {
+            user = update.getInlineQuery().getFrom();
+        }
         if (user == null) {
-            throw new BotApiException("User not found");
+            throw new BotApiException("User not found in update");
         }
         String chatId = user.getId().toString();
         return new SimpleInfo(chatId, Set.of("ADMIN"));

--- a/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleRoleProviderTest.java
+++ b/examples/simple-bot/src/test/java/io/lonmstalker/examples/simplebot/SimpleRoleProviderTest.java
@@ -1,0 +1,17 @@
+package io.lonmstalker.examples.simplebot;
+
+import io.lonmstalker.tgkit.core.exception.BotApiException;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SimpleRoleProviderTest {
+
+    @Test
+    void resolveFailsWhenUserMissing() {
+        SimpleRoleProvider provider = new SimpleRoleProvider();
+        Update update = new Update();
+        assertThrows(BotApiException.class, () -> provider.resolve(update));
+    }
+}


### PR DESCRIPTION
## Summary
- safely resolve user in `SimpleRoleProvider`
- throw `BotApiException` when no user info is present
- add test demonstrating no `NullPointerException`

## Testing
- `mvn -q -Dspotless.check.skip=true -Dspotless.apply.skip=true test` *(fails: Plugin com.diffplug.spotless:spotless-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684ec30861888325bcdc51ac50b68a21