### PR TITLE
Handle preHandle errors in BotAdapterImpl

### DIFF
--- a/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
+++ b/core/src/main/java/io/lonmstalker/tgkit/core/bot/BotAdapterImpl.java
@@ -45,10 +45,10 @@ public class BotAdapterImpl implements BotAdapter {
     @Override
     public @Nullable BotApiMethod<?> handle(@NonNull Update update) {
         List<BotInterceptor> interceptors = bot.config().getGlobalInterceptors();
-        interceptors.forEach(i -> i.preHandle(update));
         BotResponse response = null;
         Exception error = null;
         try {
+            interceptors.forEach(i -> i.preHandle(update));
             response = doHandle(update);
             interceptors.forEach(i -> i.postHandle(update));
             return response != null ? response.getMethod() : null;

--- a/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotAdapterImplTest.java
+++ b/core/src/test/java/io/lonmstalker/tgkit/core/bot/BotAdapterImplTest.java
@@ -1,0 +1,63 @@
+package io.lonmstalker.tgkit.core.bot;
+
+import io.lonmstalker.tgkit.core.BotResponse;
+import io.lonmstalker.tgkit.core.interceptor.BotInterceptor;
+import io.lonmstalker.tgkit.core.user.BotUserInfo;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.junit.jupiter.api.Test;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class BotAdapterImplTest {
+
+    @Test
+    void exception_in_preHandle_invokes_afterCompletion() {
+        TestInterceptor interceptor = new TestInterceptor();
+        BotConfig config = BotConfig.builder()
+                .globalInterceptors(List.of(interceptor))
+                .build();
+        Bot bot = mock(Bot.class);
+        when(bot.config()).thenReturn(config);
+        BotAdapterImpl adapter = new BotAdapterImpl(
+                bot,
+                (u, t) -> new org.telegram.telegrambots.meta.api.objects.Message(),
+                u -> new DummyUser());
+
+        Update update = new Update();
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> adapter.handle(update));
+
+        assertSame(ex, interceptor.error);
+        assertTrue(interceptor.afterCompletionCalled);
+    }
+
+    private static class DummyUser implements BotUserInfo {
+        @Override public @NonNull String chatId() { return "1"; }
+        @Override public @NonNull Set<String> roles() { return Set.of(); }
+    }
+
+    private static class TestInterceptor implements BotInterceptor {
+        boolean afterCompletionCalled;
+        Exception error;
+
+        @Override
+        public void preHandle(@NonNull Update update) {
+            throw new RuntimeException("boom");
+        }
+
+        @Override
+        public void postHandle(@NonNull Update update) {
+            // no-op
+        }
+
+        @Override
+        public void afterCompletion(@NonNull Update update, BotResponse response, Exception ex) {
+            afterCompletionCalled = true;
+            error = ex;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- move interceptor preHandle calls inside try block in `BotAdapterImpl`
- add test ensuring `afterCompletion` gets called when `preHandle` throws

## Testing
- `mvn -q test` *(fails: Could not resolve plugins due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684ec30d475883258e67847f642db828